### PR TITLE
Bensinc chap 6 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ Credit: [@omundy](https://github.com/omundy)
 
 With `InventoryObject` selected, in the Canvas Scaler component, set `Reference Pixels Per Unit` to 32.
 
+#### Chapter 6, Page 223-227
+Credit: [@bensinc](https://github.com/bensinc)
+
+Simplu setting itemImages[i].enabled and quantityText.enable to true doesn't cause them to appear. Instead, use .gameObject.SetActive(true) on each of them.
+
 
 #### Chapter 7, Page 263
 Credit: [@omundy](https://github.com/omundy)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ With `InventoryObject` selected, in the Canvas Scaler component, set `Reference 
 #### Chapter 6, Page 223-227
 Credit: [@bensinc](https://github.com/bensinc)
 
-Simplu setting itemImages[i].enabled and quantityText.enable to true doesn't cause them to appear. Instead, use .gameObject.SetActive(true) on each of them.
+Simply setting itemImages[i].enabled and quantityText.enable to true doesn't cause them to appear. Instead, use .gameObject.SetActive(true) on each of them.
 
 
 #### Chapter 7, Page 263


### PR DESCRIPTION
I'm not sure if this is due to a newer version of Unity or something else, but I had to use SetActive instead of just enabled = true to get inventory items to appear when using the prefabs with enabled set to false, in order to hide the empty images.