### PR TITLE
Chapter 8 - Ammo 'teleport' fix

### DIFF
--- a/Chapter 8/Arc.cs
+++ b/Chapter 8/Arc.cs
@@ -8,7 +8,7 @@ public class Arc : MonoBehaviour
         var startPosition = transform.position;
         var percentComplete = 0.0f;
 
-        while (percentComplete <= 1.0f)
+        while (percentComplete <= 1.0f  && gameObject.activeSelf)
         {
             // Time.deltaTime is the time elapsed since the last frame was drawn
             percentComplete += Time.deltaTime / duration;


### PR DESCRIPTION
Hello there!

I bumped into a rather rare issue while shooting - ammo would teleport instead of travelling (with the Arc class) properly.
This would only happen if:
1. An enemy had been hit
2. Player fired again in under ~0.7ms or less

![ezgif com-optimize](https://user-images.githubusercontent.com/26847645/68560223-e7a37280-041e-11ea-9532-879fb3a00f57.gif)

I've noticed that once a collision is detected on Ammo OnTriggerEnter2D, Ammo gameObject is disabled. As such, it's free to be reused by the Weapon FireAmmo, as on the SpawnAmmo method it checks the ammoPool for the first disabled Ammo object it can find for reuse.
My suspicion is that since the Arc TravelArc method is ran as a Coroutine, when the Ammo is disabled through a collision, the TravelArc Coroutine is likely paused/temporarily stopped, rather than removed/destroyed/truly stopped. So it resumes with the re-enabled Ammo object alongside the new TravelArc coroutine, and the two coroutines cause erratic behavior. 
My knowledge and experience with Unity is too limited to know for sure when it comes to such Coroutine stuff, though.

In any case, my quick fix was to just add an extra condition on the Travel Arc while loop, to only perform the Arc animation if the object is still active. It seemed to stop the wrong behavior from happening.

PS: Although I added a few things to the project, nothing was added/removed/changed from the Weapon, Ammo and Arc code (until this change) that would affect their original behavior.

